### PR TITLE
Use wikimedia/cdb ~2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.2",
+		"php": ">=7.2",
 		"ext-mbstring": "*",
-		"wikimedia/cdb": "~1.0",
+		"wikimedia/cdb": "~1.0|~2.0",
 		"wikimedia/textcat": "~1.1"
 	},
 	"autoload": {


### PR DESCRIPTION
MediaWiki core 1.38 >= uses wikimedia/cdb ~ 2.0.0

See: https://gerrit.wikimedia.org/r/c/mediawiki/core/+/751443